### PR TITLE
Catch ImportError while importing cupy

### DIFF
--- a/vspyplugin/cuda.py
+++ b/vspyplugin/cuda.py
@@ -348,7 +348,7 @@ try:
         ...
 
     this_backend.set_available(True)
-except ModuleNotFoundError as e:
+except (ImportError, ModuleNotFoundError) as e:
     this_backend.set_available(False, e)
 
     class PyPluginCudaBase(PyPluginUnavailableBackendBase[FD_T, DT_T]):  # type: ignore

--- a/vspyplugin/cupy.py
+++ b/vspyplugin/cupy.py
@@ -266,7 +266,7 @@ try:
             return output_func
 
     this_backend.set_available(True)
-except ModuleNotFoundError as e:
+except (ImportError, ModuleNotFoundError) as e:
     this_backend.set_available(False, e)
 
     class PyPluginCupyBase(PyPluginUnavailableBackendBase[FD_T, DT_T]):  # type: ignore


### PR DESCRIPTION
cupy throws `ImportError` if it fails to load the CUDA dynamic libraries (such as libcuda.so.1). Catch this to mark the backend as unavailable.